### PR TITLE
Function wcs_to_celestial_frame

### DIFF
--- a/src/Reproject.jl
+++ b/src/Reproject.jl
@@ -3,5 +3,6 @@ module Reproject
 using FITSIO, WCS
 
 include("parsers.jl")
+include("utils.jl")
 
 end # module

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,3 @@
-const UNDEFINED    = 987654321.0e99        # from WCS.jl
-
 """
     wcs_to_celestial_frame(wcs::WCSTransform)
 
@@ -8,12 +6,6 @@ The reference frame supported in Julia are FK5, ICRS and Galactic.
 """
 function wcs_to_celestial_frame(wcs::WCSTransform)
     radesys = wcs.radesys
-    
-    if wcs.equinox != UNDEFINED
-        equinox = wcs.equinox
-    else
-        equinox = nothing
-    end
     
     xcoord = wcs.ctype[1][1:4]
     ycoord = wcs.ctype[2][1:4]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,38 @@
+const UNDEFINED    = 987654321.0e99        # from WCS.jl
+
+"""
+    wcs_to_celestial_frame(wcs::WCSTransform)
+
+Returns the reference frame of a WCSTransform.
+The reference frame supported in Julia are FK5, ICRS and Galactic.
+"""
+function wcs_to_celestial_frame(wcs::WCSTransform)
+    radesys = wcs.radesys
+    
+    if wcs.equinox != UNDEFINED
+        equinox = wcs.equinox
+    else
+        equinox = nothing
+    end
+    
+    xcoord = wcs.ctype[1][1:4]
+    ycoord = wcs.ctype[2][1:4]
+    
+    if radesys == ""
+        if xcoord == "RA--" && ycoord == "DEC-"
+            if equinox === nothing
+                radesys = "ICRS"
+            elseif equinox < 1984.0
+                radesys = "FK4"
+            else
+                radesys = "FK5"
+            end  
+        elseif xcoord == "GLON" && ycoord == "GLAT"
+            radesys = "Gal"
+        elseif xcoord == "TLON" && ycoord == "TLAT"
+            radesys = "ITRS"
+        end
+    end
+    
+    return radesys
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -19,15 +19,7 @@ function wcs_to_celestial_frame(wcs::WCSTransform)
     ycoord = wcs.ctype[2][1:4]
     
     if radesys == ""
-        if xcoord == "RA--" && ycoord == "DEC-"
-            if equinox === nothing
-                radesys = "ICRS"
-            elseif equinox < 1984.0
-                radesys = "FK4"
-            else
-                radesys = "FK5"
-            end  
-        elseif xcoord == "GLON" && ycoord == "GLAT"
+        if xcoord == "GLON" && ycoord == "GLAT"
             radesys = "Gal"
         elseif xcoord == "TLON" && ycoord == "TLAT"
             radesys = "ITRS"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,4 +10,5 @@ rp = pyimport("reproject")
 
 @testset "Reproject.jl" begin
     include("parsers.jl")
+    include("utils.jl")
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,3 +1,4 @@
+using Reproject: wcs_to_celestial_frame
 @testset "wcs to celestial frame" begin
     wcs1 = WCSTransform(2;
                        ctype = ["RA---AIR", "DEC--AIR"],
@@ -20,7 +21,7 @@
                        ctype = ["RA---AIR", "DEC--AIR"],
                        radesys = "UNK" 
                       )
-    
+
     @test wcs_to_celestial_frame(wcs1) == "ICRS"
     @test wcs_to_celestial_frame(wcs2) == "FK4"
     @test wcs_to_celestial_frame(wcs3) == "FK5"
@@ -28,4 +29,3 @@
     @test wcs_to_celestial_frame(wcs5) == "ITRS"
     @test wcs_to_celestial_frame(wcs6) == "UNK"
 end
-

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,31 @@
+@testset "wcs to celestial frame" begin
+    wcs1 = WCSTransform(2;
+                       ctype = ["RA---AIR", "DEC--AIR"],
+                       )
+    wcs2 = WCSTransform(2;
+                       ctype = ["RA---AIR", "DEC--AIR"],
+                       equinox = 1888.67 
+                       )
+    wcs3 = WCSTransform(2;
+                       ctype = ["RA---AIR", "DEC--AIR"],
+                       equinox = 2000 
+                       )
+    wcs4 = WCSTransform(2;
+                       ctype = ["GLON--", "GLAT--"], 
+                       )
+    wcs5 = WCSTransform(2;
+                       ctype = ["TLON", "TLAT"],
+                      )
+    wcs6 = WCSTransform(2;
+                       ctype = ["RA---AIR", "DEC--AIR"],
+                       radesys = "UNK" 
+                      )
+    
+    @test wcs_to_celestial_frame(wcs1) == "ICRS"
+    @test wcs_to_celestial_frame(wcs2) == "FK4"
+    @test wcs_to_celestial_frame(wcs3) == "FK5"
+    @test wcs_to_celestial_frame(wcs4) == "Gal"
+    @test wcs_to_celestial_frame(wcs5) == "ITRS"
+    @test wcs_to_celestial_frame(wcs6) == "UNK"
+end
+


### PR DESCRIPTION
A utility function which outputs axis types information of a WCSTransform.
Reference: http://docs.astropy.org/en/stable/api/astropy.wcs.Wcsprm.html#astropy.wcs.Wcsprm.axis_types
Usage in py ver. : https://github.com/astropy/reproject/blob/2adbfe770b9b8d2fc11ed0cff89146f352aeaf40/reproject/interpolation/core_full.py#L76

**Edit:** The function `axis type` can be simplified to `wcs_to_celestial_frame` in it's usage, thus replaced it.
- [X] Function
- [X] Tests
- [X] Documentation
