### PR TITLE
data matrix and WCSTransform tuple type parser

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -5,7 +5,7 @@ Reprojects image data to a new projection using interpolation.
 
 # Arguments
 - `input_data`: Image data which is being reprojected.
-                It can be an ImageHDU, FITS object or name of a FITS file.
+                It can be an ImageHDU, FITS object, name of a FITS file or a tuple of image matrix and WCSTransform.
 - `output_projection`: Frame in which data is reprojected.
                        Frame can be taken from WCSTransform object, ImageHDU, FITS or name of FITS file.
 - `shape_out`: Shape of image after reprojection.
@@ -17,7 +17,7 @@ Reprojects image data to a new projection using interpolation.
 - `hud_out:` Used to specify HDU number when giving output projection as FITS or name of FITS file.
 """
 function reproject(input_data, output_projection; shape_out = nothing, order::Int = 1, hdu_in::Int = 1, hdu_out::Int = 1)
-    if input_data isa ImageHDU
+    if input_data isa ImageHDU || input_data isa Tuple{AbstractArray, WCSTransform}
         array_in, wcs_out = parse_input_data(input_data)
     else
         array_in, wcs_out = parse_input_data(input_data, hdu_in)

--- a/src/parsers.jl
+++ b/src/parsers.jl
@@ -1,5 +1,6 @@
 """
     parse_input_data(input_data::ImageHDU)
+    parse_input_data(input_data::Tuple{AbstractArray, WCSTransform})
     parse_input_data(input_data::String, hdu_in)
     parse_input_data(input_data::FITS, hdu_in)
 
@@ -12,6 +13,10 @@ Parse input data and returns an Array and WCS object.
 """
 function parse_input_data(input_data::ImageHDU)
     return read(input_data), WCS.from_header(read_header(input_data, String))[1]
+end
+
+function parse_input_data(input_data::Tuple{AbstractArray, WCSTransform})
+    return input_data[1], input_data[2]
 end
 
 function parse_input_data(input_data::String, hdu_in)

--- a/test/parsers.jl
+++ b/test/parsers.jl
@@ -21,6 +21,18 @@ using Reproject: parse_input_data, parse_output_projection
         @test result[2] isa WCSTransform
     end
 
+    @testset "data matrix and WCSTransform tuple" begin
+        wcs = WCSTransform(2;
+                          cdelt = [-0.066667, 0.066667],
+                          ctype = ["RA---AIR", "DEC--AIR"],
+                          crpix = [-234.75, 8.3393],
+                          crval = [0., -90],
+                          pv    = [(2, 1, 45.0)])
+        result = parse_input_data((indata, wcs))
+        @test result[1] isa Array
+        @test result[2] isa WCSTransform
+    end
+
     @testset "Single HDU FITS file" begin
         result = parse_input_data(f, 1)
         @test result[1] isa Array


### PR DESCRIPTION
This type of parser is required in https://github.com/JuliaAstro/AstroImages.jl/pull/15.
It's the base type utilized in reproject. Technically nothing is being parsed here it being the base type. But, a utility method was required.